### PR TITLE
Remove all dependencies

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,16 +1,14 @@
 #!/usr/bin/env node
 'use strict';
-const meow = require('meow');
+const process = require('process');
 const terminalLink = require('terminal-link');
 
-const cli = meow(`
-	Usage
-	  $ terminal-link <text> <url>
+if (process.argv.length !== 4) {
+	process.stderr.write('usage: terminal-link TEXT URL\n');
+	process.exit(1);
+}
 
-	Example
-	  $ terminal-link 'My Website' 'https://sindresorhus.com'
-`);
-
-const [text, url] = cli.input;
+const text = process.argv[2];
+const url = process.argv[3];
 
 console.log(terminalLink(text, url));

--- a/cli.js
+++ b/cli.js
@@ -1,14 +1,11 @@
 #!/usr/bin/env node
 'use strict';
 const process = require('process');
-const terminalLink = require('terminal-link');
 
 if (process.argv.length !== 4) {
 	process.stderr.write('usage: terminal-link TEXT URL\n');
 	process.exit(1);
 }
 
-const text = process.argv[2];
-const url = process.argv[3];
-
-console.log(terminalLink(text, url));
+process.stdout.write('\u001B]8;;' + process.argv[3] + '\u0007' +
+	process.argv[2] + '\u001B]8;;\u0007\n');

--- a/license
+++ b/license
@@ -1,6 +1,7 @@
 MIT License
 
 Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
+Copyright (c) 2018 Sijmen J. Mulder <ik@sjmulder.nl>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
 	"dependencies": {},
 	"devDependencies": {
 		"ava": "*",
-		"execa": "^0.10.0",
 		"xo": "*"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -34,9 +34,7 @@
 		"console",
 		"command-line"
 	],
-	"dependencies": {
-		"terminal-link": "^1.0.0"
-	},
+	"dependencies": {},
 	"devDependencies": {
 		"ava": "*",
 		"execa": "^0.10.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
 		"command-line"
 	],
 	"dependencies": {
-		"meow": "^4.0.0",
 		"terminal-link": "^1.0.0"
 	},
 	"devDependencies": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
 		"node": ">=6"
 	},
 	"scripts": {
-		"test": "xo && ava"
+		"test": "xo && ./test.js"
 	},
 	"files": [
 		"cli.js"
@@ -36,7 +36,6 @@
 	],
 	"dependencies": {},
 	"devDependencies": {
-		"ava": "*",
 		"xo": "*"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
 		"node": ">=6"
 	},
 	"scripts": {
-		"test": "xo && ./test.js"
+		"test": "./test.js"
 	},
 	"files": [
 		"cli.js"
@@ -35,7 +35,5 @@
 		"command-line"
 	],
 	"dependencies": {},
-	"devDependencies": {
-		"xo": "*"
-	}
+	"devDependencies": {}
 }

--- a/readme.md
+++ b/readme.md
@@ -20,11 +20,6 @@ usage: terminal-link TEXT URL
 ```
 
 
-## Related
-
-- [terminal-link](https://github.com/sindresorhus/terminal-link) - API for this module
-
-
 ## License
 
 MIT © [Sindre Sorhus](https://sindresorhus.com)

--- a/readme.md
+++ b/readme.md
@@ -22,4 +22,5 @@ usage: terminal-link TEXT URL
 
 ## License
 
-MIT © [Sindre Sorhus](https://sindresorhus.com)
+MIT © [Sindre Sorhus](https://sindresorhus.com),
+[Sijmen J. Mulder](mailto:ik@sjmulder.nl)

--- a/readme.md
+++ b/readme.md
@@ -15,13 +15,8 @@ $ npm install --global terminal-link-cli
 ## Usage
 
 ```
-$ terminal-link --help
-
-  Usage
-    $ terminal-link <text> <url>
-
-  Example
-    $ terminal-link 'My Website' 'https://sindresorhus.com'
+$ terminal-link
+usage: terminal-link TEXT URL
 ```
 
 

--- a/test.js
+++ b/test.js
@@ -1,11 +1,7 @@
+import {execSync} from 'child_process';
 import test from 'ava';
-import execa from 'execa';
 
-test('main', async t => {
-	const {stdout} = await execa('./cli.js', ['My Website', 'https://sindresorhus.com'], {
-		env: {
-			FORCE_HYPERLINK: 1
-		}
-	});
-	t.is(stdout, '\u001B]8;;https://sindresorhus.com\u0007My Website\u001B]8;;\u0007');
+test('main', t => {
+	const output = execSync('./cli.js "My Website" "https://sindresorhus.com"');
+	t.is(output.toString(), '\u001B]8;;https://sindresorhus.com\u0007My Website\u001B]8;;\u0007\n');
 });

--- a/test.js
+++ b/test.js
@@ -1,7 +1,8 @@
-import {execSync} from 'child_process';
-import test from 'ava';
+#!/usr/bin/env node
 
-test('main', t => {
-	const output = execSync('./cli.js "My Website" "https://sindresorhus.com"');
-	t.is(output.toString(), '\u001B]8;;https://sindresorhus.com\u0007My Website\u001B]8;;\u0007\n');
-});
+const {execSync} = require('child_process');
+const assert = require('assert');
+
+assert.strictEqual(
+	execSync('./cli.js "My Website" "https://sindresorhus.com"').toString(),
+	'\u001B]8;;https://sindresorhus.com\u0007My Website\u001B]8;;\u0007\n');


### PR DESCRIPTION
Hi,

Noticing that `npm install` pulls in 60 MB worth of packages, and finding that a little excessive, I've managed to trim the dependencies down to 0 with the only notable user facing change being the removal of the support check, justified as follows:

>  1. The check is fragile, testing against specific terminal versions instead
>     of employing something like terminfo, but also testing environment
>     variables for certain continuous integration services and such.
> 
>  2. The plain text output of terminal apps should speak for itself. Even on
>     supported terminals, attributes like colours and URLs may be stripped for
>     many reasons. Hence, either output the full URL, or accept that the link
>     may not be a link.

The `xo` linter was removed with no replacement. It depends on 469 packages but is of limited benefit for so little source code.