### PR TITLE
Fix package bin name

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 		"url": "sindresorhus.com"
 	},
 	"bin": {
-		"link": "cli.js"
+		"terminal-link": "cli.js"
 	},
 	"engines": {
 		"node": ">=6"


### PR DESCRIPTION
Related to #1

Refer to the 2.0.0 documentation, the command should be `terminal-link`.